### PR TITLE
Reboot policy specification

### DIFF
--- a/reboot.md
+++ b/reboot.md
@@ -1,8 +1,6 @@
 # Reboot Policy in DM
 
-- See the `sites/test-site/groups.yml` for the example of the data model edits to include reboot policy details. The hope is that everything we would need for boot policy would live in the same file so it's easy to find the entire reboot policy.
-
-Influenced by what I've seen in [virtualbox docs](https://www.virtualbox.org/manual/ch08.html) `--nicbootprio` is a number that specifies which NIC should be booted first.
+- See the `sites/test-site/groups.yml` for the example of the data model edits to include reboot policy details. The hope is that everything we would need for boot policy would live in the same file so it's easy to find the entire reboot policy. We will attempt to replicate as much of the [drone](https://github.com/drone/drone) workflow when it comes to executing pipelines.
 
 ## Requirements
 
@@ -14,20 +12,28 @@ Influenced by what I've seen in [virtualbox docs](https://www.virtualbox.org/man
 
 ### Fields for `host_group` and `host`
 
-More specificity will always take precedence.
+- `flush_pipeline`: the pipeline of containers to execute before shutting down a machine. This is exactly like `drone.yml`, the intent is that we will run containers from top to bottom, only proceeding to the next container if the prior passed. Not declaring a `flush_pipeline` would indicate vaquero can shut down the host without taking any actions. Default: empty
 
-- `boot_prio`: is an integer field that could be under a host_group or an individual host. Vaquero will order priority from lowest to highest. A `boot_prio` =: 0 will be booted before a `boot_prio` of 1. If the `boot_prio` of different groups or nodes have the same score, the order of booting will happen in any order within that boot group. One can think of a decimal number, `<group_bootP>.<host_bootP>` we will boot from lowest to highest, ties have no guaranteed order. Default is 0.
-
-- `flush_pipeline`: the pipeline of containers to execute before shutting down a machine. This is exactly like `drone.yml`, the intent is that we will run containers from top to bottom, only proceeding to the next container if the prior passed. Not declaring a `flush_pipeline` would indicate vaquero can shut down the host without taking any actions.
-
-- `resurrect_pipeline`: the pipeline of containers to execute after a reboot. This is exactly like `drone.yml`, the intent is that we will run containers from top to bottom, only proceeding to the next container if the prior passed. Not declaring a `resurrect_pipeline` would indicate vaquero can bring up the host without taking any actions.
+- `validate_pipeline`: the pipeline of containers to execute after a reboot. This is exactly like `drone.yml`, the intent is that we will run containers from top to bottom, only proceeding to the next container if the prior passed. Not declaring a `validate_pipeline` would indicate vaquero can bring up the host without taking any actions. Default: empty
 
 ## Fields for `host_group` only
 
 - `max_concurrent`: an integer or percentage of max number of machines that could reboot at one time. For percentage we will round down, the last batch will be the remainder. A value of 0 would mean all machines can be rebooted at the same time, conversely a percentage of 100% could do the same. Default is 1.
 
+- `safe_deps`: a list of dependencies that this host group has and can concurrently boot with. Default: empty
+
+- `block_deps`: a list of dependencies that this host group must wait for its completion to begin its booting process. Default: empty
+
+- `val_on_deps`: a list of dependencies that this host_group should run its `validate_pipeline` given a dependency in this list is changed. Default: empty
+
+- `max_fail`: the maximum number or percentage of machines that is considered an acceptable failure rate. This is just to protect one machine hardware failure from blocking the entire update. Default: 0
+
+## Fields for `host` only
+
+- `boot_number`: the integer that specifies the booting order of the hosts in the group. We will boot from lowest to highest, ties will boot in any order. Default: 0
+
 ## Concerns:
 
 - Private docker registry, might need more details. URL, User, Password. See how [Drone Docs](http://readme.drone.io/usage/build_test/) handles this.
-- Don't want to clutter the data model, but don't want to make people re-write the host_groups and hosts to specify BMC options. Regardless, all the BMC details should be explicit and live in one file. We could have another `policy.yml` butin that document you would have to type every host_group / host you'd want included in the policy.
-- How exactly does one flush / resurrect from the vaquero agent. (Need to ssh or something into a given machine and we will look at exit codes to decide if a step in the pipeline was a success or failure. `os.Exit(0) = success` and `os.Exit(1) = failure`)
+- Don't want to clutter the data model, but don't want to make people re-write the host_groups and hosts to specify BMC options. Regardless, all the BMC details should be explicit and live in one file.
+- How exactly does one flush / resurrect from the vaquero agent. (Need to ssh or something into a given machine and we will look at exit codes to decide if a step in the pipeline was a success or failure. `os.Exit(0) = success` and `os.Exit(1) = failure`) We need to capture the log output from that container.

--- a/reboot.md
+++ b/reboot.md
@@ -12,9 +12,9 @@
 
 ### Fields for `host_group` and `host`
 
-- `flush_pipeline`: the pipeline of containers to execute before shutting down a machine. This is exactly like `drone.yml`, the intent is that we will run containers from top to bottom, only proceeding to the next container if the prior passed. Not declaring a `flush_pipeline` would indicate vaquero can shut down the host without taking any actions. Default: empty
+- `flush_pipeline`: the pipeline of containers to execute before shutting down a machine. This is exactly like `drone.yml`, the intent is that we will run containers from top to bottom, only proceeding to the next container if the prior passed. Not declaring a `flush_pipeline` would indicate vaquero can shut down the host without taking any actions. This pipeline will run serially, and stop at the first failure. Default: empty
 
-- `validate_pipeline`: the pipeline of containers to execute after a reboot. This is exactly like `drone.yml`, the intent is that we will run containers from top to bottom, only proceeding to the next container if the prior passed. Not declaring a `validate_pipeline` would indicate vaquero can bring up the host without taking any actions. Default: empty
+- `validate_pipeline`: the pipeline of containers to execute after a reboot. This is exactly like `drone.yml`, the intent is that we will run containers from top to bottom, only proceeding to the next container if the prior passed. Not declaring a `validate_pipeline` would indicate vaquero can bring up the host without taking any actions. This pipeline will always run every validation step and report all validation results, and will fail if at least one step fails. Default: empty
 
 ## Fields for `host_group` only
 

--- a/reboot.md
+++ b/reboot.md
@@ -1,0 +1,33 @@
+# Reboot Policy in DM
+
+- See the `sites/test-site/groups.yml` for the example of the data model edits to include reboot policy details. The hope is that everything we would need for boot policy would live in the same file so it's easy to find the entire reboot policy.
+
+Influenced by what I've seen in [virtualbox docs](https://www.virtualbox.org/manual/ch08.html) `--nicbootprio` is a number that specifies which NIC should be booted first.
+
+## Requirements
+
+1. Group by node type, with limit on # of concurrent nodes rebooted, ordered by groups. (Works for Kubernetes -- masters then minions, no more than X at once.)
+2. Explicitly ordered reboots for certain clusters -- for example: [ instance1, instance3, instance2, instance5, instance4, instance6 ]. (Works for MemSQL.)
+
+
+## New Data Model Fields
+
+### Fields for `host_group` and `host`
+
+More specificity will always take precedence.
+
+- `boot_prio`: is an integer field that could be under a host_group or an individual host. Vaquero will order priority from lowest to highest. A `boot_prio` =: 0 will be booted before a `boot_prio` of 1. If the `boot_prio` of different groups or nodes have the same score, the order of booting will happen in any order within that boot group. One can think of a decimal number, `<group_bootP>.<host_bootP>` we will boot from lowest to highest, ties have no guaranteed order. Default is 0.
+
+- `flush_pipeline`: the pipeline of containers to execute before shutting down a machine. This is exactly like `drone.yml`, the intent is that we will run containers from top to bottom, only proceeding to the next container if the prior passed. Not declaring a `flush_pipeline` would indicate vaquero can shut down the host without taking any actions.
+
+- `resurrect_pipeline`: the pipeline of containers to execute after a reboot. This is exactly like `drone.yml`, the intent is that we will run containers from top to bottom, only proceeding to the next container if the prior passed. Not declaring a `resurrect_pipeline` would indicate vaquero can bring up the host without taking any actions.
+
+## Fields for `host_group` only
+
+- `max_concurrent`: an integer or percentage of max number of machines that could reboot at one time. For percentage we will round down, the last batch will be the remainder. A value of 0 would mean all machines can be rebooted at the same time, conversely a percentage of 100% could do the same. Default is 1.
+
+## Concerns:
+
+- Private docker registry, might need more details. URL, User, Password. See how [Drone Docs](http://readme.drone.io/usage/build_test/) handles this.
+- Don't want to clutter the data model, but don't want to make people re-write the host_groups and hosts to specify BMC options. Regardless, all the BMC details should be explicit and live in one file. We could have another `policy.yml` butin that document you would have to type every host_group / host you'd want included in the policy.
+- How exactly does one flush / resurrect from the vaquero agent. (Need to ssh or something into a given machine and we will look at exit codes to decide if a step in the pipeline was a success or failure. `os.Exit(0) = success` and `os.Exit(1) = failure`)

--- a/reboot.md
+++ b/reboot.md
@@ -48,6 +48,8 @@
 
   - `continue`: will ignore errors and continue with rolling out the updated model.
 
+- `timeout`: the time in seconds to wait for a specific tasks that is run on the agent
+
 ## Concerns:
 
 - Private docker registry, might need more details. URL, User, Password. See how [Drone Docs](http://readme.drone.io/usage/build_test/) handles this.

--- a/reboot.md
+++ b/reboot.md
@@ -32,8 +32,23 @@
 
 - `boot_number`: the integer that specifies the booting order of the hosts in the group. We will boot from lowest to highest, ties will boot in any order. Default: 0
 
+## [`policy.md`](https://github.com/CiscoCloud/vaquero-examples/blob/boot-prio/sites/test-site/policy.yml)
+
+- `boot_times`: a list of time frames that vaquero is allowed to reboot machines in.
+
+- `ignore_deps`: a boolean that would specify if vaquero should ignore dependencies. Specifying `true` would have every machine boot at the same time, not taking any dependency work into account.
+
+- `on_failure: retry`: an integer that specifies how many times vaquero should retry a specific host.
+
+- `on_failure: then`: a string that specifies the options `rollback`, `halt`, `continue` and is the behavior vaquero will take given a failure occurs.
+
+  - `rollback`: will bring the affected hosts back to the last valid data model.
+
+  - `halt`: will stop the update in place and no longer take action on that inventory.
+
+  - `continue`: will ignore errors and continue with rolling out the updated model.
+
 ## Concerns:
 
 - Private docker registry, might need more details. URL, User, Password. See how [Drone Docs](http://readme.drone.io/usage/build_test/) handles this.
-- Don't want to clutter the data model, but don't want to make people re-write the host_groups and hosts to specify BMC options. Regardless, all the BMC details should be explicit and live in one file.
 - How exactly does one flush / resurrect from the vaquero agent. (Need to ssh or something into a given machine and we will look at exit codes to decide if a step in the pipeline was a success or failure. `os.Exit(0) = success` and `os.Exit(1) = failure`) We need to capture the log output from that container.

--- a/reboot.md
+++ b/reboot.md
@@ -18,7 +18,7 @@
 
 ## Fields for `host_group` only
 
-- `max_concurrent`: an integer or percentage of max number of machines that could reboot at one time. For percentage we will round down, the last batch will be the remainder. A value of 0 would mean all machines can be rebooted at the same time, conversely a percentage of 100% could do the same. Default is 1.
+- `max_concurrent`: an integer or percentage of max number of machines that could reboot at one time. For percentage we will round down, the last batch will be the remainder. A value of 0 would mean all machines can be rebooted at the same time, conversely a percentage of 100% could do the same. Default is 0.
 
 - `safe_deps`: a list of dependencies that this host group has and can concurrently boot with. Default: empty
 
@@ -26,7 +26,7 @@
 
 - `val_on_deps`: a list of dependencies that this host_group should run its `validate_pipeline` given a dependency in this list is changed. Default: empty
 
-- `max_fail`: the maximum number or percentage of machines that is considered an acceptable failure rate. This is just to protect one machine hardware failure from blocking the entire update. Default: 0
+- `max_fail`: the maximum number or percentage of machines that is considered an acceptable failure rate. This is to protect one machine hardware failure from blocking the entire update. Default: 0
 
 ## Fields for `host` only
 

--- a/reboot.md
+++ b/reboot.md
@@ -38,15 +38,13 @@
 
 - `ignore_deps`: a boolean that would specify if vaquero should ignore dependencies. Specifying `true` would have every machine boot at the same time, not taking any dependency work into account.
 
-- `on_failure: retry`: an integer that specifies how many times vaquero should retry a specific host.
+- `timeout`: the time in seconds to wait for a specific tasks that is run on the agent
 
-- `on_failure: then`: a string that specifies the options `rollback`, `halt`, `continue` and is the behavior vaquero will take given a failure occurs.
+- `on_failure`:
 
-  - `rollback`: will bring the affected hosts back to the last valid data model.
+  - `retry`: an integer that specifies how many times vaquero should retry a specific host.
 
-  - `halt`: will stop the update in place and no longer take action on that inventory.
-
-  - `continue`: will ignore errors and continue with rolling out the updated model.
+  - `then`: a string that specifies the options `rollback`, `halt`, `continue` and is the behavior vaquero will take given a failure occurs. `rollback`: will bring the affected hosts back to the last valid data model. `halt`: will stop the update in place and no longer take action on that inventory. `continue`: will ignore errors and continue with rolling out the updated model.
 
 ## Concerns:
 

--- a/sites/test-site/groups.yml
+++ b/sites/test-site/groups.yml
@@ -1,21 +1,54 @@
 ---
 host_group: etcd-cluster
+bmc:
+  boot_prio: 0
+  max_concurrent: 1
+  flush_pipeline:
+    image: <docker_image>
+    commands:
+      - run commands
+    image: <docker_image2>
+    commands:
+      - run commands
+  resurrect_pipeline:
+    image: <docker_image>
+    commands:
+      - run commands
 hosts:
 - name: host1
     etcd_name: node1
+  bmc:
+    boot_prio: 1
 - name: host2
   metadata:
     etcd_name: node2
+  bmc:
+    boot_prio: 0
 - name: host3
   metadata:
     etcd_name: node3
+  bmc:
+    boot_prio: 2
 ---
 host_group: etcd-proxy
+bmc:
+  boot_prio: 1
+  max_concurrent: 5%
 hosts:
   - name: proxy1
   - name: proxy2
 ---
 host_group: clevos
+bmc:
+  boot_prio: 2
+  max_concurrent: 1
+  flush_pipeline:
+    image: <docker_image>
+    commands:
+      - run commands other details
+    image: <docker_image2>
+    commands:
+      - run commands other details
 hosts:
 - name: clevos1
   metadata:

--- a/sites/test-site/groups.yml
+++ b/sites/test-site/groups.yml
@@ -1,16 +1,25 @@
 ---
 host_group: etcd-cluster
 bmc:
-  boot_prio: 0
   max_concurrent: 3
+  safe_deps: [<dependencies>]
+  block_deps: [<dependencies>]
+  val_on_deps: [<dependencies>]
+  max_fail: 1
   flush_pipeline:
     image: <docker_image>
+    pull: true
+    environment:
+      - TEST = hahaha
     commands:
       - run commands
     image: <docker_image2>
+    pull: true
+    environment:
+      - TEST = hahaha
     commands:
       - run commands
-  resurrect_pipeline:
+  validate_pipeline:
     image: <docker_image>
     commands:
       - run commands
@@ -18,29 +27,30 @@ hosts:
 - name: host1
     etcd_name: node1
   bmc:
-    boot_prio: 1
+    boot_number: 1
 - name: host2
   metadata:
     etcd_name: node2
   bmc:
-    boot_prio: 0
+    boot_number: 0
 - name: host3
   metadata:
     etcd_name: node3
   bmc:
-    boot_prio: 2
+    boot_number: 2
 ---
 host_group: etcd-proxy
 bmc:
-  boot_prio: 1
+  boot_number: 1
   max_concurrent: 5%
+  max_fail: 0
 hosts:
   - name: proxy1
   - name: proxy2
 ---
 host_group: clevos
 bmc:
-  boot_prio: 2
+  boot_number: 2
   max_concurrent: 1
   flush_pipeline:
     image: <docker_image>

--- a/sites/test-site/groups.yml
+++ b/sites/test-site/groups.yml
@@ -2,7 +2,7 @@
 host_group: etcd-cluster
 bmc:
   boot_prio: 0
-  max_concurrent: 1
+  max_concurrent: 3
   flush_pipeline:
     image: <docker_image>
     commands:

--- a/sites/test-site/policy.yml
+++ b/sites/test-site/policy.yml
@@ -1,6 +1,7 @@
 ---
 boot_times: [23:30-05:00]
 ignore_deps: false
+timeout: 60
 on_failure:
   retry: 3
   then: rollback

--- a/sites/test-site/policy.yml
+++ b/sites/test-site/policy.yml
@@ -1,0 +1,6 @@
+---
+boot_times: [23:30-05:00]
+ignore_deps: false
+on_failure:
+  retry: 3
+  then: rollback


### PR DESCRIPTION
- Includes my proposal for the addition of a reboot policy into the data model.
- See [reboot.md](https://github.com/CiscoCloud/vaquero-examples/blob/boot-prio/reboot.md) for a text description of what I did.

@adamschaub @benschumacher @mikeynap @meganokeefe @mcaulfield 

If I get a thumbs up I can start implementing these fields in the model and ensure it passes the validator
